### PR TITLE
Add an Anchor tag with Name attribute to Headlines

### DIFF
--- a/block/HeadlineTrait.php
+++ b/block/HeadlineTrait.php
@@ -62,7 +62,7 @@ trait HeadlineTrait
 	protected function renderHeadline($block)
 	{
 		$tag = 'h' . $block['level'];
-		return "<$tag>" . $this->renderAbsy($block['content']) . "</$tag>\n";
+		return sprintf("<a name=\"%s\"></a><%s>%s</%s>\n", strtolower($this->renderAbsy($block['content'])), $tag, $this->renderAbsy($block['content']), $tag);
 	}
 
 	abstract protected function parseInline($text);


### PR DESCRIPTION
This is to allow you to link to a specific headline on a page.